### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-check.yaml
+++ b/.github/workflows/merge-check.yaml
@@ -13,6 +13,8 @@ concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
+permissions:
+  contents: read
 jobs:
   unit-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/usbharu/todo-user/security/code-scanning/1](https://github.com/usbharu/todo-user/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the least privilege necessary. Since the workflow only checks out code and runs tests, it does not require write access to any resources. The minimal permission required is `contents: read`, which allows the workflow to read repository contents but not modify them. This block should be added at the root level of the workflow file (above `jobs:`) to apply to all jobs unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
